### PR TITLE
開発者が複数いるときに、名前が1行で全て表示されていたのを改行で表示されるように修正

### DIFF
--- a/src/app/_features/product/detail/components/ProductDetailItems.tsx
+++ b/src/app/_features/product/detail/components/ProductDetailItems.tsx
@@ -67,14 +67,14 @@ const ProductDetailItems: FC<TProps> = ({
           <Chips key={skill} label={skill} />
         ))}
         <h4>開発者</h4>
-        <p>
+        <div>
           {developer.map((name) => (
             <span key={name}>
               {name}
               <br />
             </span>
           ))}
-        </p>
+        </div>
         {productURL && (
           <>
             <h4>URL</h4>

--- a/src/app/_features/product/detail/components/ProductDetailItems.tsx
+++ b/src/app/_features/product/detail/components/ProductDetailItems.tsx
@@ -67,7 +67,14 @@ const ProductDetailItems: FC<TProps> = ({
           <Chips key={skill} label={skill} />
         ))}
         <h4>開発者</h4>
-        <p>{developer}</p>
+        <p>
+          {developer.map((name) => (
+            <span key={name}>
+              {name}
+              <br />
+            </span>
+          ))}
+        </p>
         {productURL && (
           <>
             <h4>URL</h4>


### PR DESCRIPTION
# PC
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/bcdfe109-cc3f-4fd4-bdbd-ecea898dd9d6">

# SP
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/4df8d131-4a34-4655-b2c5-4c1607ad6f78">
